### PR TITLE
Remove pypy2 from osx build, update to 7.1.1

### DIFF
--- a/.azure-pipelines/run_docker_build.sh
+++ b/.azure-pipelines/run_docker_build.sh
@@ -5,7 +5,7 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
-set -xeuo pipefail
+set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename $THISDIR)"
@@ -28,12 +28,25 @@ fi
 ARTIFACTS="$FEEDSTOCK_ROOT/build_artifacts"
 
 if [ -z "$CONFIG" ]; then
-    echo "Need to set CONFIG env variable"
+    set +x
+    FILES=`ls .ci_support/linux_*`
+    CONFIGS=""
+    for file in $FILES; do
+        CONFIGS="${CONFIGS}'${file:12:-5}' or ";
+    done
+    echo "Need to set CONFIG env variable. Value can be one of ${CONFIGS:0:-4}"
     exit 1
 fi
 
-pip install shyaml
-DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )
+if [ -z "${DOCKER_IMAGE}" ]; then
+    SHYAML_INSTALLED="$(shyaml --version || echo NO)"
+    if [ "${SHYAML_INSTALLED}" == "NO" ]; then
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
+        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+    else
+        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
+    fi
+fi
 
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Current build status
       <img src="https://img.shields.io/badge/Windows-disabled-lightgrey.svg" alt="Windows disabled">
     </td>
   </tr>
+![ppc64le disabled](https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg)
 </table>
 
 Current release info

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,7 @@ PYPY3_SRC_DIR=$SRC_DIR/pypy3
 
 if [ $(uname) == Darwin ]; then
     export CC=$CLANG
-    export PYTHON=$SRC_DIR/pypy2-osx/bin/pypy
+    export PYTHON=${PREFIX}/bin/python
 fi
 
 if [ $(uname) == Linux ]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,12 @@
 {% set name = "pypy3.6" %}
-{% set version = "7.1.1b" %}
+{% set version = "7.1.1" %}
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: {{ version }}b
 
 source:
-  - url: https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-src.tar.bz2
-    fn: pypy3.6-v7.1.1-src.tar.bz2
+  - url: https://bitbucket.org/pypy/pypy/downloads/{{ name }}-v{{ version }}-src.tar.bz2
     sha256: 6a3ef876e3691a54f4cff045028ec3be94ab9beb2e99f051b83175302c1899a8
     folder: pypy3
     patches:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,14 @@
 {% set name = "pypy3.6" %}
-{% set version = "7.1.0b" %}
+{% set version = "7.1.1b" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  - url: https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.0-src.tar.bz2
-    fn: pypy3.6-v7.1.0-src.tar.bz2
-    sha256: faa81f469bb2a7cbd22c64f22d4b4ddc5a1f7c798d43b7919b629b932f9b1c6f
+  - url: https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-src.tar.bz2
+    fn: pypy3.6-v7.1.1-src.tar.bz2
+    sha256: 6a3ef876e3691a54f4cff045028ec3be94ab9beb2e99f051b83175302c1899a8
     folder: pypy3
     patches:
       - fficurses.patch
@@ -16,11 +16,6 @@ source:
       - tklib_build.patch
       - clibffi.patch  # [osx]
       - darwin.patch  # [osx]
-
-  - url: https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-osx64.tar.bz2  # [osx]
-    fn: pypy2-v5.9.0-osx64.tar.bz2  # [osx]
-    sha256: 94de50ed80c7f6392ed356c03fd54cdc84858df43ad21e9e971d1b6da0f6b867  # [osx]
-    folder: pypy2-osx  # [osx]
 
 build:
   number: 0


### PR DESCRIPTION
As noted in #2, there is newer release of PyPy!
Also, dropped pypy2 usage for macOS build,

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
~* [ ] Bumped the build number (if the version is unchanged)~
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
