### PR TITLE
temporary fix in buffer format size

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,7 +12,6 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -38,3 +38,13 @@ jobs:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+        if [ -d build_artifacts ]; then
+          echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
+        fi
+    displayName: Check for conda build artifacts
+    condition: succeededOrFailed()
+
+  - publish: build_artifacts/
+    artifact: conda_artifacts_$(CONFIG)_$(system.JobId)
+    condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,7 +11,6 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -26,3 +26,13 @@ jobs:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+        if [ -d /Users/runner/miniforge3/conda-bld/ ]; then
+          echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
+        fi
+    displayName: Check for conda build artifacts
+    condition: succeededOrFailed()
+
+  - publish: /Users/runner/miniforge3/conda-bld/
+    artifact: conda_artifacts_$(CONFIG)_$(system.JobId)
+    condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -4,6 +4,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,7 @@ source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
 
 
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ Home: http://pypy.org/
 
 Package license: MIT
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pypy3.6-feedstock/blob/master/LICENSE.txt)
 
 Summary: PyPy is a Python interpreter and just-in-time compiler.
-
-
 
 Current build status
 ====================

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,1 +1,6 @@
 conda_forge_output_validation: true
+
+azure:
+  # toggle for storing the conda build_artifacts directory (including the
+  # built packages) as an Azure pipeline artifact that can be downloaded
+  store_build_artifacts: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,10 +23,11 @@ source:
       - patches/0020-ppc-jit-fix
       - patches/0021-ppc-test-fix1
       - patches/0022-ppc-test-fix2
+      - patches/0023-buffer-format
     
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
   skip_compile_pyc:
     - lib*

--- a/recipe/patches/0023-buffer-format
+++ b/recipe/patches/0023-buffer-format
@@ -1,0 +1,13 @@
+diff -r b6277db08da8 -r f03656fb7117 pypy/module/cpyext/parse/cpyext_object.h
+--- a/pypy/module/cpyext/parse/cpyext_object.h  Fri Oct 23 02:58:46 2020 +0300
++++ b/pypy/module/cpyext/parse/cpyext_object.h  Thu Oct 29 14:12:14 2020 +0200
+@@ -70,7 +70,7 @@
+ /* Py3k buffer interface, adapted for PyPy */
+ /* XXX remove this constant, us a PyObject_VAR_HEAD instead */
+ #define Py_MAX_NDIMS 36
+-#define Py_MAX_FMT 128
++#define Py_MAX_FMT 512
+ typedef struct bufferinfo {
+     void *buf;
+     PyObject *obj;        /* owned reference */
+

--- a/recipe/patches/0023-buffer-format
+++ b/recipe/patches/0023-buffer-format
@@ -1,6 +1,6 @@
 diff -r b6277db08da8 -r f03656fb7117 pypy/module/cpyext/parse/cpyext_object.h
---- a/pypy/module/cpyext/parse/cpyext_object.h  Fri Oct 23 02:58:46 2020 +0300
-+++ b/pypy/module/cpyext/parse/cpyext_object.h  Thu Oct 29 14:12:14 2020 +0200
+--- pypy/module/cpyext/parse/cpyext_object.h  Fri Oct 23 02:58:46 2020 +0300
++++ pypy/module/cpyext/parse/cpyext_object.h  Thu Oct 29 14:12:14 2020 +0200
 @@ -70,7 +70,7 @@
  /* Py3k buffer interface, adapted for PyPy */
  /* XXX remove this constant, us a PyObject_VAR_HEAD instead */


### PR DESCRIPTION
It turns out hard-coding the format length was a bad idea, and causes various problems with scikit-learn. This is a temporary fix, a more permanent one will be in the next version of PyPy
xref scikit-learn/scikit-learn#18624
xref scikit-learn/scikit-learn#17994

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
