### PR TITLE
break the posix build into stages

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,13 +5,14 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_name_suffix3.7:
         CONFIG: linux_64_name_suffix3.7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        SHORT_CONFIG_NAME: linux_64_name_suffix3.7
   timeoutInMinutes: 360
 
   steps:
@@ -39,8 +40,7 @@ jobs:
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
   - script: |
-        full_artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
-        artifact_name=`echo "$full_artifact_name" | head -c 80`
+        artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG_NAME)"
         echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d build_artifacts ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,6 +11,7 @@ jobs:
       osx_64_name_suffix3.7:
         CONFIG: osx_64_name_suffix3.7
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: osx_64_name_suffix3.7
   timeoutInMinutes: 360
 
   steps:
@@ -27,8 +28,7 @@ jobs:
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
   - script: |
-        full_artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
-        artifact_name=`echo "$full_artifact_name" | head -c 80`
+        artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG_NAME)"
         echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d /Users/runner/miniforge3/conda-bld/ ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,6 +11,7 @@ jobs:
       win_64_name_suffix3.7:
         CONFIG: win_64_name_suffix3.7
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG_NAME: win_64_name_suffix3.7
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
@@ -92,8 +93,7 @@ jobs:
         PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
-        set full_artifact_name=conda_artifacts_$(build.BuildID)_$(CONFIG)
-        set artifact_name=%full_artifact_name:~0,80%
+        set artifact_name=conda_artifacts_$(build.BuildID)_$(SHORT_CONFIG_NAME)
         echo ##vso[task.setVariable variable=ARTIFACT_NAME]%artifact_name%
         if exist $(CONDA_BLD_PATH)\\ (
           echo ##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true

--- a/.ci_support/win_64_name_suffix3.7.yaml
+++ b/.ci_support/win_64_name_suffix3.7.yaml
@@ -12,16 +12,12 @@ libffi:
 - '3.3'
 name_suffix:
 - '3.7'
-ncurses:
-- '6.2'
 openssl:
 - 1.1.1
 pin_run_as_build:
   bzip2:
     max_pin: x
   libffi:
-    max_pin: x.x
-  ncurses:
     max_pin: x.x
   openssl:
     max_pin: x.x.x

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 *.pyc
 
 build_artifacts
-
-*.swp

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-About pypy3.6
+About pypy3.7
 =============
 
 Home: http://pypy.org/
@@ -64,10 +64,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pypy3.6-green.svg)](https://anaconda.org/conda-forge/pypy3.6) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pypy3.6.svg)](https://anaconda.org/conda-forge/pypy3.6) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pypy3.6.svg)](https://anaconda.org/conda-forge/pypy3.6) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pypy3.6.svg)](https://anaconda.org/conda-forge/pypy3.6) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pypy3.7-green.svg)](https://anaconda.org/conda-forge/pypy3.7) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pypy3.7.svg)](https://anaconda.org/conda-forge/pypy3.7) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pypy3.7.svg)](https://anaconda.org/conda-forge/pypy3.7) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pypy3.7.svg)](https://anaconda.org/conda-forge/pypy3.7) |
 
-Installing pypy3.6
+Installing pypy3.7
 ==================
 
-Installing `pypy3.6` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `pypy3.7` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -125,17 +125,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating pypy3.6-feedstock
+Updating pypy3.7-feedstock
 ==========================
 
-If you would like to improve the pypy3.6 recipe or build a new
+If you would like to improve the pypy3.7 recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/pypy3.6-feedstock are
+Note that all branches in the conda-forge/pypy3.7-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -39,8 +39,8 @@ cd $GOAL_DIR
 ${PYTHON} ../../rpython/bin/rpython --make-jobs ${CPU_COUNT} --no-compile --shared -Ojit targetpypystandalone.py
 cd  ${SRC_DIR}/usession-pypy3-0/testing_1
 make -j ${CPU_COUNT}
-cp *.so ${GOAL_DIR}
 cp ${PYPY_PKG_NAME}* ${GOAL_DIR}
+cp lib${PYPY_PKG_NAME}* ${GOAL_DIR}
 cd $GOAL_DIR
 
 if [[ "$target_platform" == "osx-64" ]]; then
@@ -98,6 +98,7 @@ mv $PREFIX/site-packages/README $PREFIX/lib/python${PY_VERSION}/site-packages/
 rm -rf $PREFIX/site-packages
 ln -sf $PREFIX/lib/python${PY_VERSION}/site-packages $PREFIX/site-packages
 
+echo PWD is ${PWD}
 # Build the c-extension modules for the standard library
 pypy -c "import _testcapi"
 pypy -c "import _ctypes_test"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,9 +30,18 @@ BUILD_DIR=${PREFIX}/../build
 TARGET_DIR=${PREFIX}/../target
 ARCHIVE_NAME="${PYPY_PKG_NAME}-${PKG_VERSION}"
 
-# Build PyPy.
+# Build PyPy in stages
+# Force the build to use this directory
+export PYPY_USESSION_BASENAME=pypy3
+export PYPY_USESSION_DIR=${SRC_DIR}
+
 cd $GOAL_DIR
-${PYTHON} ../../rpython/bin/rpython --make-jobs ${CPU_COUNT} --shared -Ojit targetpypystandalone.py
+${PYTHON} ../../rpython/bin/rpython --make-jobs ${CPU_COUNT} --no-compile --shared -Ojit targetpypystandalone.py
+cd  ${SRC_DIR}/usession-pypy3-0/testing_1
+make -j ${CPU_COUNT}
+cp *.so ${GOAL_DIR}
+cp ${PYPY_PKG_NAME}* ${GOAL_DIR}
+cd $GOAL_DIR
 
 if [[ "$target_platform" == "osx-64" ]]; then
     # Temporally set the @rpath of the generated PyPy binary to ${PREFIX}.
@@ -89,7 +98,12 @@ mv $PREFIX/site-packages/README $PREFIX/lib/python${PY_VERSION}/site-packages/
 rm -rf $PREFIX/site-packages
 ln -sf $PREFIX/lib/python${PY_VERSION}/site-packages $PREFIX/site-packages
 
-# Build the cache for the standard library
+# Build the c-extension modules for the standard library
+pypy -c "import _testcapi"
+pypy -c "import _ctypes_test"
+pypy -c "import _testmultiphase"
+
+# Run the python stdlib tests
 timeout 60m pypy3 -m test --pgo -j${CPU_COUNT} || true;
 cd $PREFIX
 pypy -m lib2to3.pgen2.driver lib-python/3/lib2to3/Grammar.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ source:
     folder: pypy2-binary                                                      # [win]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [name_suffix=="3.6"]
   skip_compile_pyc:
     - lib*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ source:
       - patches/pre-7.3.6-0002.patch
       - patches/pre-7.3.6-0003.patch
       - patches/pre-7.3.6-0004.patch
+      - patches/pre-7.3.6-0005.patch
 
   - url: https://downloads.python.org/pypy/pypy2.7-v7.3.5-win64.zip           # [win]
     sha256: 0b90eded11ba89a526c4288f17fff7e75000914ac071bd6d67912748ae89d761  # [win]

--- a/recipe/patches/pre-7.3.6-0005.patch
+++ b/recipe/patches/pre-7.3.6-0005.patch
@@ -1,0 +1,24 @@
+# Node ID 79776d971f8c4fdaf148ae2c816fa7fe25405238
+# Parent  0788a72db0243e40fcc7e8a3e8c428777feeafd2
+customize compiler
+
+diff -r 0788a72db024 -r 79776d971f8c lib_pypy/_pypy_testcapi.py
+--- a/lib_pypy/_pypy_testcapi.py	Sat Jun 19 23:15:30 2021 +0300
++++ b/lib_pypy/_pypy_testcapi.py	Mon Jun 21 04:43:09 2021 +0300
+@@ -61,7 +61,7 @@
+     assert output_dir is not None
+ 
+     from distutils.ccompiler import new_compiler
+-    from distutils import log
++    from distutils import log, sysconfig
+     log.set_verbosity(3)
+ 
+     compiler = new_compiler()
+@@ -72,6 +72,7 @@
+         ccflags = ['-D_CRT_SECURE_NO_WARNINGS']
+     else:
+         ccflags = ['-fPIC', '-Wimplicit-function-declaration']
++    sysconfig.customize_compiler(compiler)
+     res = compiler.compile([os.path.join(thisdir, csource)],
+                            include_dirs=[include_dir],
+                            extra_preargs=ccflags,


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
At the end of translation, PyPy by default builds the cffi import libraries using `--embed-dependencies`, which is wrong for conda. It also swallows the output for the final stages, which makes debugging CI more difficult.

By adding the `--no-compile` option, the translation will stop before calling `make`, which is the last option to terminate traslation. Maybe someday PyPy will grow an option to only skip the cffi build stage, which is complicated for ... reasons. So the PR adds the option, then dives into the emitted source directory, calls `make`, and copies out the artifacts.

Commands to continue from there were already in the `build.sh script`, but I added pre-building the c-extension modules to avoid race conditions when building them in multi-threaded tests. Maybe I should disable the stdlib tests, they take a long time?

<!--
Please add any other relevant info below:
-->
xref #40