### PR TITLE
patch distutils.command.install schema for conda

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ source:
       - patches/clibffi.patch     # [osx]
       - patches/darwin.patch      # [osx]
       - patches/site-and-sysconfig-conda.patch  # [win]
+      - patches/distutils-install.patch         # [win]
       # Patches by @mingwandroid from python-feedstock
       - patches/0009-runtime_library_dir_option-Use-1st-word-of-CC-as-com.patch
       - patches/0012-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -38,7 +39,7 @@ source:
     folder: pypy2-binary                                                      # [win]
 
 build:
-  number: 1
+  number: 2
   skip: True  # [name_suffix=="3.6"]
   skip_compile_pyc:
     - lib*

--- a/recipe/patches/distutils-install.patch
+++ b/recipe/patches/distutils-install.patch
@@ -1,0 +1,32 @@
+# Branch conda
+# Node ID 85c317f36cd8fc1962c1776a6cfb1df3572c518c
+# Parent  e9052b361691a2de3cfb86712ecd4609ac3aff12
+conda schema fixes for distutils
+
+diff -r e9052b361691 -r 85c317f36cd8 lib-python/3/distutils/command/install.py
+--- a/lib-python/3/distutils/command/install.py	Sun Jun 13 10:37:17 2021 +0300
++++ b/lib-python/3/distutils/command/install.py	Thu Jun 24 16:35:13 2021 +0300
+@@ -56,19 +56,13 @@
+         },
+     'nt': WINDOWS_SCHEME,
+     'pypy': {
+-        'purelib': '$base/site-packages',
+-        'platlib': '$base/site-packages',
+-        'headers': '$base/include/$dist_name',
++        'purelib': '$base/lib/python$py_version_short/site-packages',
++        'platlib': '$platbase/lib/python$py_version_short/site-packages',
++        'headers': '$base/include/python$py_version_short$abiflags/$dist_name',
+         'scripts': '$base/bin',
+         'data'   : '$base',
+         },
+-    'pypy_nt': {
+-        'purelib': '$base/site-packages',
+-        'platlib': '$base/site-packages',
+-        'headers': '$base/include/$dist_name',
+-        'scripts': '$base/Scripts',
+-        'data'   : '$base',
+-        },
++    'pypy_nt': WINDOWS_SCHEME,
+     }
+ 
+ # user site schemes


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

fixes #44 

I assume this is windows only? Not clear to me how posix works, so I changed it anyway, even though the patch is marked `[win]`