### PR TITLE
use libffi instead of older vendored version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,13 +36,14 @@ source:
       - patches/pre-7.3.6-0005.patch
       - patches/pre-7.3.6-0006.patch
       - patches/pre-7.3.6-0007.patch
+      - patches/pre-7.3.6-0008.patch
 
   - url: https://downloads.python.org/pypy/pypy2.7-v7.3.5-win64.zip           # [win]
     sha256: 0b90eded11ba89a526c4288f17fff7e75000914ac071bd6d67912748ae89d761  # [win]
     folder: pypy2-binary                                                      # [win]
 
 build:
-  number: 3
+  number: 4
   skip: True  # [name_suffix=="3.6"]
   skip_compile_pyc:
     - lib*

--- a/recipe/patches/pre-7.3.6-0008.patch
+++ b/recipe/patches/pre-7.3.6-0008.patch
@@ -2,8 +2,8 @@
 # Parent  77787b8f4c49115346d1e9cbaf48734137417738
 
 diff -r 77787b8f4c49 -r fc8388ffecc6 lib-python/3/venv/__init__.py
---- a/lib-python/3/venv/__init__.py	Mon Apr 12 07:11:48 2021 +0200
-+++ b/lib-python/3/venv/__init__.py	Sun Jul 11 12:46:37 2021 +0300
+--- a/lib-python/3/venv/__init__.py	2021-4-12 07:11:48.000 +0200
++++ b/lib-python/3/venv/__init__.py	2021-7-11 12:46:37.000 +0300
 @@ -259,9 +259,9 @@
                      if not os.path.islink(path):
                          os.chmod(path, 0o755)
@@ -17,8 +17,8 @@ diff -r 77787b8f4c49 -r fc8388ffecc6 lib-python/3/venv/__init__.py
                  src_library = os.path.join(os.path.dirname(context.executable),
                                             libname)
 diff -r 77787b8f4c49 -r fc8388ffecc6 pypy/tool/release/package.py
---- a/pypy/tool/release/package.py	Mon Apr 12 07:11:48 2021 +0200
-+++ b/pypy/tool/release/package.py	Sun Jul 11 12:46:37 2021 +0300
+--- a/pypy/tool/release/package.py	2021-4-12 07:11:48.000 +0200
++++ b/pypy/tool/release/package.py	Sun Jul 11 12:46:37.000 2021 +0300
 @@ -156,7 +156,9 @@
              print("Picking %s" % str(pypyw))
          # Can't rename a DLL
@@ -31,8 +31,8 @@ diff -r 77787b8f4c49 -r fc8388ffecc6 pypy/tool/release/package.py
              tkinter_dir = lib_pypy.join('_tkinter')
              win_extras += [('tcl86t.dll', tkinter_dir), ('tk86t.dll', tkinter_dir)]
 diff -r 77787b8f4c49 -r fc8388ffecc6 rpython/rlib/clibffi.py
---- a/rpython/rlib/clibffi.py	Mon Apr 12 07:11:48 2021 +0200
-+++ b/rpython/rlib/clibffi.py	Sun Jul 11 12:46:37 2021 +0300
+--- a/rpython/rlib/clibffi.py	2021-4-12 07:11:48.000 +0200
++++ b/rpython/rlib/clibffi.py	2021-7-11 12:46:37.000 +0300
 @@ -38,10 +38,7 @@
  
  if _WIN32:
@@ -94,8 +94,8 @@ diff -r 77787b8f4c49 -r fc8388ffecc6 rpython/rlib/clibffi.py
  else:
      c_ffi_call_return_type = lltype.Void
 diff -r 77787b8f4c49 -r fc8388ffecc6 rpython/translator/driver.py
---- a/rpython/translator/driver.py	Mon Apr 12 07:11:48 2021 +0200
-+++ b/rpython/translator/driver.py	Sun Jul 11 12:46:37 2021 +0300
+--- a/rpython/translator/driver.py	2021-4-12 07:11:48.000 +0200
++++ b/rpython/translator/driver.py	2021-7-11 12:46:37.000 +0300
 @@ -507,6 +507,11 @@
                          newname = newexename.new(basename=soname.basename)
                          shutil.copyfile(str(name), str(newname.new(ext=ext)))

--- a/recipe/patches/pre-7.3.6-0008.patch
+++ b/recipe/patches/pre-7.3.6-0008.patch
@@ -58,7 +58,7 @@ diff -r 77787b8f4c49 -r fc8388ffecc6 rpython/rlib/clibffi.py
          includes = ['ffi.h', 'windows.h'],
 -        libraries = ['kernel32'],
 -        include_dirs = [libffidir, cdir],
-+        libraries = ['kernel32', 'libffi-7'],
++        libraries = ['kernel32', 'libffi'],
 +        # include_dirs = [libffidir, cdir],
          separate_module_sources = separate_module_sources,
          post_include_bits = post_include_bits,

--- a/recipe/patches/pre-7.3.6-0008.patch
+++ b/recipe/patches/pre-7.3.6-0008.patch
@@ -1,0 +1,110 @@
+# Node ID fc8388ffecc6e0476cf14f55c45da31d1caa448d
+# Parent  77787b8f4c49115346d1e9cbaf48734137417738
+
+diff -r 77787b8f4c49 -r fc8388ffecc6 lib-python/3/venv/__init__.py
+--- a/lib-python/3/venv/__init__.py	Mon Apr 12 07:11:48 2021 +0200
++++ b/lib-python/3/venv/__init__.py	Sun Jul 11 12:46:37 2021 +0300
+@@ -259,9 +259,9 @@
+                     if not os.path.islink(path):
+                         os.chmod(path, 0o755)
+             #
+-            # PyPy extension: also copy the main library, not just the
++            # PyPy extension: also copy needed dlls, not just the
+             # small executable
+-            for libname in ['libpypy3-c.so', 'libpypy3-c.dylib']:
++            for libname in ['libpypy3-c.so', 'libpypy3-c.dylib', 'libffi-7.dll']:
+                 dest_library = os.path.join(binpath, libname)
+                 src_library = os.path.join(os.path.dirname(context.executable),
+                                            libname)
+diff -r 77787b8f4c49 -r fc8388ffecc6 pypy/tool/release/package.py
+--- a/pypy/tool/release/package.py	Mon Apr 12 07:11:48 2021 +0200
++++ b/pypy/tool/release/package.py	Sun Jul 11 12:46:37 2021 +0300
+@@ -156,7 +156,9 @@
+             print("Picking %s" % str(pypyw))
+         # Can't rename a DLL
+         win_extras = [('lib' + POSIX_EXE + '-c.dll', None),
+-                      ('sqlite3.dll', lib_pypy)]
++                      ('sqlite3.dll', lib_pypy),
++                      ('libffi-7.dll', None),
++                     ]
+         if not options.no__tkinter:
+             tkinter_dir = lib_pypy.join('_tkinter')
+             win_extras += [('tcl86t.dll', tkinter_dir), ('tk86t.dll', tkinter_dir)]
+diff -r 77787b8f4c49 -r fc8388ffecc6 rpython/rlib/clibffi.py
+--- a/rpython/rlib/clibffi.py	Mon Apr 12 07:11:48 2021 +0200
++++ b/rpython/rlib/clibffi.py	Sun Jul 11 12:46:37 2021 +0300
+@@ -38,10 +38,7 @@
+ 
+ if _WIN32:
+     from rpython.rlib import rwin32
+-
+-if _WIN32:
+     separate_module_sources = ['''
+-    #include "src/precommondefs.h"
+     #include <stdio.h>
+     #include <windows.h>
+ 
+@@ -107,22 +104,22 @@
+          ])
+ else:
+     USE_C_LIBFFI_MSVC = True
+-    libffidir = py.path.local(cdir).join('src', 'libffi_msvc')
++    # libffidir = py.path.local(cdir).join('src', 'libffi_msvc')
+     if not _WIN64:
+         asm_ifc = 'win32.c'
+     else:
+         asm_ifc = 'win64.asm'
+     eci = ExternalCompilationInfo(
+         includes = ['ffi.h', 'windows.h'],
+-        libraries = ['kernel32'],
+-        include_dirs = [libffidir, cdir],
++        libraries = ['kernel32', 'libffi-7'],
++        # include_dirs = [libffidir, cdir],
+         separate_module_sources = separate_module_sources,
+         post_include_bits = post_include_bits,
+-        separate_module_files = [libffidir.join('ffi.c'),
+-                                 libffidir.join('prep_cif.c'),
+-                                 libffidir.join(asm_ifc),
+-                                 libffidir.join('pypy_ffi.c'),
+-                                 ],
++        # separate_module_files = [libffidir.join('ffi.c'),
++        #                          libffidir.join('prep_cif.c'),
++        #                          libffidir.join(asm_ifc),
++        #                          libffidir.join('pypy_ffi.c'),
++        #                          ],
+         )
+ 
+ FFI_TYPE_P = lltype.Ptr(lltype.ForwardReference())
+@@ -265,7 +262,7 @@
+     return rffi.llexternal(name, args, result, compilation_info=eci, calling_conv='win')
+ 
+ 
+-if not _MSVC:
++if 1 or not _MSVC:
+     def check_fficall_result(result, flags):
+         pass # No check
+ else:
+@@ -329,7 +326,7 @@
+ 
+ c_ffi_prep_cif = external('ffi_prep_cif', [FFI_CIFP, FFI_ABI, rffi.UINT,
+                                            FFI_TYPE_P, FFI_TYPE_PP], rffi.INT)
+-if _MSVC:
++if 0 and _MSVC:
+     c_ffi_call_return_type = rffi.INT
+ else:
+     c_ffi_call_return_type = lltype.Void
+diff -r 77787b8f4c49 -r fc8388ffecc6 rpython/translator/driver.py
+--- a/rpython/translator/driver.py	Mon Apr 12 07:11:48 2021 +0200
++++ b/rpython/translator/driver.py	Sun Jul 11 12:46:37 2021 +0300
+@@ -507,6 +507,11 @@
+                         newname = newexename.new(basename=soname.basename)
+                         shutil.copyfile(str(name), str(newname.new(ext=ext)))
+                         self.log.info("copied: %s" % (newname,))
++                    # HACK: copy libcffi-7.dll which is required for venvs
++                    # At some point, we should stop doing this, and instead
++                    # use the artifact from packaging the build instead
++                    libffi = py.path.local.sysfind('libffi-7.dll')
++                    shutil.copyfile(str(libffi), os.getcwd() + r'\libffi-7.dll')
+             self.c_entryp = newexename
+         self.log.info("created: %s" % (self.c_entryp,))
+ 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

It turns out PyPy was vendoring a very old version of libffi for msvc. Conda provides a newer version, so use it. This seems to fix the segfaults in conda-forge/numpy-feedstock#238. While the patch comes from an upstream branch, the branch itself requires pypa/virtualenv#2141 so I am optimistically marking this as part of the next pypy release.