### PR TITLE
fix jit bug in xmm register use in windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,13 +37,14 @@ source:
       - patches/pre-7.3.6-0006.patch
       - patches/pre-7.3.6-0007.patch
       - patches/pre-7.3.6-0008.patch
+      - patches/pre-7.3.6-0009.patch  # [win]
 
   - url: https://downloads.python.org/pypy/pypy2.7-v7.3.5-win64.zip           # [win]
     sha256: 0b90eded11ba89a526c4288f17fff7e75000914ac071bd6d67912748ae89d761  # [win]
     folder: pypy2-binary                                                      # [win]
 
 build:
-  number: 4
+  number: 5
   skip: True  # [name_suffix=="3.6"]
   skip_compile_pyc:
     - lib*

--- a/recipe/patches/pre-7.3.6-0009.patch
+++ b/recipe/patches/pre-7.3.6-0009.patch
@@ -1,0 +1,26 @@
+diff -r cfc38b565a4e rpython/jit/backend/x86/regalloc.py
+--- a/rpython/jit/backend/x86/regalloc.py   Thu Jul 15 16:33:54 2021 +0200
++++ b/rpython/jit/backend/x86/regalloc.py   Sun Jul 18 00:42:19 2021 +0300
+@@ -122,7 +122,8 @@
+ 
+ class X86_64_XMMRegisterManager(X86XMMRegisterManager):
+     # xmm15 reserved for scratch use
+-    all_regs = [xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10, xmm11, xmm12, xmm13, xmm14]
++    # all_regs = [xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm9, xmm10, xmm11, xmm12, xmm13, xmm14]
++    all_regs = [xmm0, xmm1, xmm2, xmm3, xmm4]
+     save_around_call_regs = all_regs
+ 
+ class X86FrameManager(FrameManager):
+diff -r cfc38b565a4e rpython/jit/backend/x86/regloc.py
+--- a/rpython/jit/backend/x86/regloc.py Thu Jul 15 16:33:54 2021 +0200
++++ b/rpython/jit/backend/x86/regloc.py Sun Jul 18 00:42:19 2021 +0300
+@@ -353,7 +353,7 @@
+ 
+ # XXX: a GPR scratch register is definitely needed, but we could probably do
+ # without an xmm scratch reg.
+-X86_64_XMM_SCRATCH_REG = xmm15
++X86_64_XMM_SCRATCH_REG = xmm5
+ 
+ # note: 'r' is after 'i' in this list, for _binaryop()
+ unrolling_location_codes = unrolling_iterable(list("irbsmajx"))
+

--- a/recipe/patches/pre-7.3.6-0009.patch
+++ b/recipe/patches/pre-7.3.6-0009.patch
@@ -1,6 +1,6 @@
-diff -r cfc38b565a4e rpython/jit/backend/x86/regalloc.py
---- a/rpython/jit/backend/x86/regalloc.py   Thu Jul 15 16:33:54 2021 +0200
-+++ b/rpython/jit/backend/x86/regalloc.py   Sun Jul 18 00:42:19 2021 +0300
+diff -r cfc38b565a4e -r 451181af7e5b rpython/jit/backend/x86/regalloc.py
+--- rpython/jit/backend/x86/regalloc.py   2021-4-12 16:33:54 2021 +0200
++++ rpython/jit/backend/x86/regalloc.py   2021-7-18 00:42:19 2021 +0300
 @@ -122,7 +122,8 @@
  
  class X86_64_XMMRegisterManager(X86XMMRegisterManager):
@@ -11,9 +11,9 @@ diff -r cfc38b565a4e rpython/jit/backend/x86/regalloc.py
      save_around_call_regs = all_regs
  
  class X86FrameManager(FrameManager):
-diff -r cfc38b565a4e rpython/jit/backend/x86/regloc.py
---- a/rpython/jit/backend/x86/regloc.py Thu Jul 15 16:33:54 2021 +0200
-+++ b/rpython/jit/backend/x86/regloc.py Sun Jul 18 00:42:19 2021 +0300
+diff -r cfc38b565a4e -r 451181af7e5b rpython/jit/backend/x86/regloc.py
+--- rpython/jit/backend/x86/regloc.py 2021-4-12 16:33:54 2021 +0200
++++ rpython/jit/backend/x86/regloc.py 2021-7-18 00:42:19 2021 +0300
 @@ -353,7 +353,7 @@
  
  # XXX: a GPR scratch register is definitely needed, but we could probably do


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

It seems PyPy's JIT did not comply with the windows x64 calling conventions. This patch is a temporary windows64-only fix, the permanent fix will be in the next release.

xref https://github.com/conda-forge/numpy-feedstock/pull/238 and [this debug document](https://hackmd.io/@mattip/segfault)