### PR TITLE
Disable copying dlls when creating windows package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ source:
       - patches/site-and-sysconfig-conda.patch    # [win]
       - patches/distutils-install.patch           # [win]
       - patches/distutils-sysconfig-get_python_lib.patch  # [win]
+      - patches/0001-Add-conda-forge-version.patch
+      - patches/0018-Disable-copying-dlls.patch
       # Patches by @mingwandroid from python-feedstock
       - patches/0009-runtime_library_dir_option-Use-1st-word-of-CC-as-com.patch
       - patches/0012-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -44,7 +46,7 @@ source:
     folder: pypy2-binary                                                      # [win]
 
 build:
-  number: 5
+  number: 6
   skip: True  # [name_suffix=="3.6"]
   skip_compile_pyc:
     - lib*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,32 +56,29 @@ requirements:
     - pkg-config        # [unix]
     - pycparser
   host:
-    - openssl
-    - libffi
-    - sqlite
-    - tk
-    - zlib
     - bzip2
     - expat
-    - ncurses  # [not win]
     - gdbm     # [not win]
-    - xz
-    - tk
-    - bzip2
-    - xorg-libx11  # [linux]
     - jom ==1.1.2  # [win]
-  run:
-    - openssl
     - libffi
+    - ncurses  # [not win]
+    - openssl
     - sqlite
     - tk
-    - zlib
-    - bzip2
-    - ncurses  # [not win]
-    - gdbm     # [not win]
+    - xorg-libx11  # [linux]
     - xz
-    - expat
+    - zlib
+  run:
     - bzip2
+    - expat
+    - gdbm     # [not win]
+    - libffi
+    - ncurses  # [not win]
+    - openssl
+    - sqlite
+    - tk
+    - xz
+    - zlib
   run_constrained:
     - pypy3.5 ==99999999999
     - pypy3.6 ==99999999999  # [name_suffix=="3.7"]

--- a/recipe/patches/0001-Add-conda-forge-version.patch
+++ b/recipe/patches/0001-Add-conda-forge-version.patch
@@ -1,0 +1,25 @@
+# HG changeset patch
+# Date 1627369254 -10800
+#      Tue Jul 27 10:00:54 2021 +0300
+# Branch conda
+# Node ID 3bd4e146c802b6a2549bedb139881814845cbb23
+# Parent  a62de68281e3bc881cddc1d56646567dc543e3cd
+add 'packaged by conda-forge' like in CPython feedstock
+
+diff -r a62de68281e3 -r 3bd4e146c802 pypy/module/sys/version.py
+--- a/pypy/module/sys/version.py	Fri Jul 02 18:18:41 2021 +0300
++++ b/pypy/module/sys/version.py	Tue Jul 27 10:00:54 2021 +0300
+@@ -55,11 +55,11 @@
+     ver = "%d.%d.%d" % (PYPY_VERSION[0], PYPY_VERSION[1], PYPY_VERSION[2])
+     if PYPY_VERSION[3] != "final":
+         ver = ver + "-%s%d" %(PYPY_VERSION[3], PYPY_VERSION[4])
+-    template = "%d.%d.%d (%s, %s, %s)\n[PyPy %s with %%s]" % (
++    template = "%d.%d.%d | packaged by conda-forge | (%s, %s, %s)\n[PyPy %s with %%s]" % (
+         CPYTHON_VERSION[0],
+         CPYTHON_VERSION[1],
+         CPYTHON_VERSION[2],
+-        get_repo_version_info(root=pypyroot)[1],
++        get_repo_version_info(root=pypyroot)[1][:8],
+         date,
+         time,
+         ver)

--- a/recipe/patches/0018-Disable-copying-dlls.patch
+++ b/recipe/patches/0018-Disable-copying-dlls.patch
@@ -1,0 +1,74 @@
+# HG changeset patch
+# Date 1627474848 -10800
+#      Wed Jul 28 15:20:48 2021 +0300
+# Branch conda
+# Node ID ffffffffffffffffffffffffffffffffffffffff
+# Parent  4aca66d6c57dd79083a1b75ea6a5b76df98eebcb
+
+
+diff -r 4aca66d6c57d lib_pypy/_ssl_build.py
+--- a/lib_pypy/_ssl_build.py
++++ b/lib_pypy/_ssl_build.py
+@@ -59,22 +59,4 @@
+ 
+ if __name__ == '__main__':
+     ffi.compile(verbose=True)
+-    if sys.platform == 'win32':
+-        # copy dlls from externals to the pwd
+-        # maybe we should link to libraries instead of the dlls
+-        # to avoid this mess
+-        import os, glob, shutil
+-        path_parts = os.environ['PATH'].split(';')
+-        candidates = [x for x in path_parts if 'externals' in x]
+ 
+-        def copy_from_path(dll):
+-            for c in candidates:
+-                files = glob.glob(os.path.join(c, dll + '*.dll'))
+-                if files:
+-                    for fname in files:
+-                        print('copying', fname)
+-                        shutil.copy(fname, '.')
+-
+-        if candidates:
+-            for lib in libraries:
+-                copy_from_path(lib)
+diff -r 4aca66d6c57d pypy/tool/release/package.py
+--- a/pypy/tool/release/package.py
++++ b/pypy/tool/release/package.py
+@@ -177,10 +177,7 @@
+             print("Picking %s" % str(pypyw))
+         # Can't rename a DLL
+         win_extras = [('lib' + POSIX_EXE + '-c.dll', None),
+-                      ('sqlite3.dll', lib_pypy)]
+-        if not options.no__tkinter:
+-            tkinter_dir = lib_pypy.join('_tkinter')
+-            win_extras += [('tcl86t.dll', tkinter_dir), ('tk86t.dll', tkinter_dir)]
++                     ]
+ 
+         for extra,target_dir in win_extras:
+             p = pypy_c.dirpath().join(extra)
+@@ -205,23 +202,6 @@
+             # Has the lib moved, was translation not 'shared', or are
+             # there no exported functions in the dll so no import
+             # library was created?
+-        if not options.no__tkinter:
+-            try:
+-                p = pypy_c.dirpath().join('tcl86t.dll')
+-                if not p.check():
+-                    p = py.path.local.sysfind('tcl86t.dll')
+-                    if p is None:
+-                        raise WindowsError("tcl86t.dll not found")
+-                tktcldir = p.dirpath().join('..').join('lib')
+-                shutil.copytree(str(tktcldir), str(pypydir.join('tcl')))
+-            except WindowsError:
+-                print("Packaging Tk runtime failed. tk86t.dll and tcl86t.dll "
+-                      "found in %s, expecting to find runtime in %s directory "
+-                      "next to the dlls, as per build "
+-                      "instructions." %(p, tktcldir), file=sys.stderr)
+-                import traceback;traceback.print_exc()
+-                raise MissingDependenciesError('Tk runtime')
+-
+     print('* Binaries:', [source.relto(str(basedir))
+                           for source, target, target_dir in binaries])
+ 
+

--- a/recipe/patches/pre-7.3.6-0008.patch
+++ b/recipe/patches/pre-7.3.6-0008.patch
@@ -16,20 +16,6 @@ diff -r 77787b8f4c49 -r fc8388ffecc6 lib-python/3/venv/__init__.py
                  dest_library = os.path.join(binpath, libname)
                  src_library = os.path.join(os.path.dirname(context.executable),
                                             libname)
-diff -r 77787b8f4c49 -r fc8388ffecc6 pypy/tool/release/package.py
---- a/pypy/tool/release/package.py	2021-4-12 07:11:48.000 +0200
-+++ b/pypy/tool/release/package.py	Sun Jul 11 12:46:37.000 2021 +0300
-@@ -156,7 +156,9 @@
-             print("Picking %s" % str(pypyw))
-         # Can't rename a DLL
-         win_extras = [('lib' + POSIX_EXE + '-c.dll', None),
--                      ('sqlite3.dll', lib_pypy)]
-+                      ('sqlite3.dll', lib_pypy),
-+                      ('libffi-7.dll', None),
-+                     ]
-         if not options.no__tkinter:
-             tkinter_dir = lib_pypy.join('_tkinter')
-             win_extras += [('tcl86t.dll', tkinter_dir), ('tk86t.dll', tkinter_dir)]
 diff -r 77787b8f4c49 -r fc8388ffecc6 rpython/rlib/clibffi.py
 --- a/rpython/rlib/clibffi.py	2021-4-12 07:11:48.000 +0200
 +++ b/rpython/rlib/clibffi.py	2021-7-11 12:46:37.000 +0300


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Replaces #50, keeping the cleanup and `sys.version` changes, but now should not copy any dlls into `lib_pypy`, rather they should be taken from the conda environment.
<!--
Please add any other relevant info below:
-->
