### PR TITLE
fix sysconfig.get_config_var['LIBDIR'] (for postgres-feedstock)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-About pypy3.7
+About pypy3.6
 =============
 
 Home: http://pypy.org/
@@ -64,10 +64,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pypy3.6-green.svg)](https://anaconda.org/conda-forge/pypy3.6) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pypy3.6.svg)](https://anaconda.org/conda-forge/pypy3.6) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pypy3.6.svg)](https://anaconda.org/conda-forge/pypy3.6) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pypy3.6.svg)](https://anaconda.org/conda-forge/pypy3.6) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pypy3.7-green.svg)](https://anaconda.org/conda-forge/pypy3.7) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pypy3.7.svg)](https://anaconda.org/conda-forge/pypy3.7) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pypy3.7.svg)](https://anaconda.org/conda-forge/pypy3.7) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pypy3.7.svg)](https://anaconda.org/conda-forge/pypy3.7) |
 
-Installing pypy3.7
+Installing pypy3.6
 ==================
 
-Installing `pypy3.7` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `pypy3.6` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -125,17 +125,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating pypy3.7-feedstock
+Updating pypy3.6-feedstock
 ==========================
 
-If you would like to improve the pypy3.7 recipe or build a new
+If you would like to improve the pypy3.6 recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/pypy3.7-feedstock are
+Note that all branches in the conda-forge/pypy3.6-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ source:
       - patches/0001-Add-conda-forge-version.patch
       - patches/0018-Disable-copying-dlls.patch
       - patches/0021-Adapt-platform-to-patch-0001.patch
+      - patches/0022-Fix-LIBDIR.patch
       # Patches by @mingwandroid from python-feedstock
       - patches/0009-runtime_library_dir_option-Use-1st-word-of-CC-as-com.patch
       - patches/0012-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -48,7 +49,7 @@ source:
     folder: pypy2-binary                                                      # [win]
 
 build:
-  number: 7
+  number: 8
   skip: True  # [name_suffix=="3.6"]
   skip_compile_pyc:
     - lib*

--- a/recipe/patches/0022-Fix-LIBDIR.patch
+++ b/recipe/patches/0022-Fix-LIBDIR.patch
@@ -1,0 +1,19 @@
+# Date 1629814779 -10800
+#      Tue Aug 24 17:19:39 2021 +0300
+# Branch conda
+# Node ID 20b5f5f0f00724967b810e5cb729e8c699bbd920
+# Parent  49ba58431c069c0f944f12f935c564d538feee79
+conda modifies the build to put the dll in base/lib not base/bin
+
+diff -r 49ba58431c06 -r 20b5f5f0f007 lib_pypy/_sysconfigdata.py
+--- a/lib_pypy/_sysconfigdata.py
++++ b/lib_pypy/_sysconfigdata.py
+@@ -37,7 +37,7 @@
+     # "mybase/bin" directory. Only when making a portable build (the default
+     # for the linux buildbots) is there even a "mybase/lib" created, even so
+     # the mybase/bin layout is left untouched.
+-    'LIBDIR': os.path.join(mybase, 'bin'),
++    'LIBDIR': os.path.join(mybase, 'lib'),
+     'INCLUDEPY': os.path.join(mybase, 'include'),
+     'LDLIBRARY': 'libpypy3-c.so',
+     'VERSION': '%d.%d' % sys.version_info[:2],


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

When looking at the [postgresql-feedstock CI failure](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=366792&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=10351) I see it cannot find `libpypy3-c.so`. That is because conda puts it in the `lib` dir, not the `bin` dir. So `sysconfig.get_config_var['LIBDIR']` needs adjustment. This may affect CMake projects as well.



<!--
Please add any other relevant info below:
-->
