### PR TITLE
Include Scripts directory in the Windows package by adding .keep file

### DIFF
--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,7 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling ['boa', 'conda-forge-ci-setup=3'] and conda-build."
+echo -e "\n\nInstalling ['conda-forge-ci-setup=3'] and conda-build."
 mamba install --update-specs --quiet --yes --channel conda-forge \
     conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://pypy.org/
 
 Package license: MIT
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pypy3.6-feedstock/blob/master/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pypy3.6-feedstock/blob/main/LICENSE.txt)
 
 Summary: PyPy is a Python interpreter and just-in-time compiler. See https://conda-forge.org/blog/posts/2020-03-10-pypy for more information about using PyPy in conda
 
@@ -21,8 +21,8 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master">
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main">
           </a>
         </summary>
         <table>
@@ -30,85 +30,85 @@ Current build status
           <tbody><tr>
               <td>linux_64_name_suffix3.8openssl1.1.1</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=linux&configuration=linux_64_name_suffix3.8openssl1.1.1" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux_64_name_suffix3.8openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_name_suffix3.8openssl3</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=linux&configuration=linux_64_name_suffix3.8openssl3" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux_64_name_suffix3.8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_name_suffix3.9openssl1.1.1</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=linux&configuration=linux_64_name_suffix3.9openssl1.1.1" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux_64_name_suffix3.9openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_name_suffix3.9openssl3</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=linux&configuration=linux_64_name_suffix3.9openssl3" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux_64_name_suffix3.9openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_name_suffix3.8openssl1.1.1</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=osx&configuration=osx_64_name_suffix3.8openssl1.1.1" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx_64_name_suffix3.8openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_name_suffix3.8openssl3</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=osx&configuration=osx_64_name_suffix3.8openssl3" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx_64_name_suffix3.8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_name_suffix3.9openssl1.1.1</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=osx&configuration=osx_64_name_suffix3.9openssl1.1.1" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx_64_name_suffix3.9openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_name_suffix3.9openssl3</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=osx&configuration=osx_64_name_suffix3.9openssl3" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx_64_name_suffix3.9openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_name_suffix3.8openssl1.1.1</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=win&configuration=win_64_name_suffix3.8openssl1.1.1" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win_64_name_suffix3.8openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_name_suffix3.8openssl3</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=win&configuration=win_64_name_suffix3.8openssl3" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win_64_name_suffix3.8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_name_suffix3.9openssl1.1.1</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=win&configuration=win_64_name_suffix3.9openssl1.1.1" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win_64_name_suffix3.9openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_name_suffix3.9openssl3</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=master&jobName=win&configuration=win_64_name_suffix3.9openssl3" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win_64_name_suffix3.9openssl3" alt="variant">
                 </a>
               </td>
             </tr>
@@ -137,16 +137,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `pypy3.8, pypy3.9` can be installed with:
+Once the `conda-forge` channel has been enabled, `pypy3.8, pypy3.9` can be installed with `conda`:
 
 ```
 conda install pypy3.8 pypy3.9
 ```
 
-It is possible to list all of the versions of `pypy3.8` available on your platform with:
+or with `mamba`:
+
+```
+mamba install pypy3.8 pypy3.9
+```
+
+It is possible to list all of the versions of `pypy3.8` available on your platform with `conda`:
 
 ```
 conda search pypy3.8 --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search pypy3.8 --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search pypy3.8 --channel conda-forge
+
+# List packages depending on `pypy3.8`:
+mamba repoquery whoneeds pypy3.8 --channel conda-forge
+
+# List dependencies of `pypy3.8`:
+mamba repoquery depends pypy3.8 --channel conda-forge
 ```
 
 
@@ -164,10 +189,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -111,3 +111,9 @@ pypy -c "import _ctypes_test"
 IF %ERRORLEVEL% NEQ 0 (Echo ERROR while building &exit /b 11)
 pypy -c "import _testmultiphase"
 IF %ERRORLEVEL% NEQ 0 (Echo ERROR while building &exit /b 11)
+
+REM Include a %PREFIX%\Scripts directory in the package. This ensures
+REM that entry_points are able to be created by downstream packages.
+if not exist "%PREFIX%\Scripts" mkdir "%PREFIX%\Scripts"
+copy /y NUL "%PREFIX%\Scripts\.keep"
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -99,6 +99,8 @@ test:
     - if not exist %PREFIX%\lib\lib2to3\Grammar{{ name_suffix }}*.pickle exit 1                  # [win]
     - if not exist %PREFIX%\lib\lib2to3\PatternGrammar{{ name_suffix }}*.pickle exit 1           # [win]
     - pypy3 -m test.test_ssl
+    # make sure Scripts dir exists so downstream entry_points are created successfully
+    - if not exist %PREFIX%\Scripts\ exit 1  # [win]
 
 about:
     home: http://pypy.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ source:
     folder: pypy2-binary                                                      # [win]
 
 build:
-  number: 1
+  number: 2
   skip_compile_pyc:
     - lib*
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
See https://github.com/conda-forge/gobject-introspection-feedstock/pull/55.

<!--
Please add any other relevant info below:
-->
Currently conda will fail to create an entry_point script/binary for downstream noarch: python packages unless the parent directory (`%PREFIX%\Scripts`) already exists. This ensures that the directory will always be created when pypy is installed, which happens to be already true for the cpython packages. This is only an issue on Windows because non-Windows entry_points go to `$PREFIX/bin` which exists because other files already go there.