### PR TITLE
MNT: rerender

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -48,7 +48,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,11 +23,10 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling ['conda-forge-ci-setup=3'] and conda-build."
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-About pypy3.9
+About pypy3.8
 =============
 
 Home: http://pypy.org/
@@ -31,84 +31,84 @@ Current build status
               <td>linux_64_name_suffix3.8openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux_64_name_suffix3.8openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_name_suffix3.8openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_name_suffix3.8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux_64_name_suffix3.8openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_name_suffix3.8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_name_suffix3.9openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux_64_name_suffix3.9openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_name_suffix3.9openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_name_suffix3.9openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux_64_name_suffix3.9openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_name_suffix3.9openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_name_suffix3.8openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx_64_name_suffix3.8openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_name_suffix3.8openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_name_suffix3.8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx_64_name_suffix3.8openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_name_suffix3.8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_name_suffix3.9openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx_64_name_suffix3.9openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_name_suffix3.9openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64_name_suffix3.9openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx_64_name_suffix3.9openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_name_suffix3.9openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_name_suffix3.8openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win_64_name_suffix3.8openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win%20win_64_name_suffix3.8openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_name_suffix3.8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win_64_name_suffix3.8openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win%20win_64_name_suffix3.8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_name_suffix3.9openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win_64_name_suffix3.9openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win%20win_64_name_suffix3.9openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64_name_suffix3.9openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6451&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win_64_name_suffix3.9openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pypy3.6-feedstock?branchName=main&jobName=win&configuration=win%20win_64_name_suffix3.9openssl3" alt="variant">
                 </a>
               </td>
             </tr>
@@ -127,10 +127,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pypy3.8-green.svg)](https://anaconda.org/conda-forge/pypy3.8) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pypy3.8.svg)](https://anaconda.org/conda-forge/pypy3.8) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pypy3.8.svg)](https://anaconda.org/conda-forge/pypy3.8) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pypy3.8.svg)](https://anaconda.org/conda-forge/pypy3.8) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pypy3.9-green.svg)](https://anaconda.org/conda-forge/pypy3.9) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pypy3.9.svg)](https://anaconda.org/conda-forge/pypy3.9) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pypy3.9.svg)](https://anaconda.org/conda-forge/pypy3.9) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pypy3.9.svg)](https://anaconda.org/conda-forge/pypy3.9) |
 
-Installing pypy3.9
+Installing pypy3.8
 ==================
 
-Installing `pypy3.9` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `pypy3.8` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -216,17 +216,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating pypy3.9-feedstock
+Updating pypy3.8-feedstock
 ==========================
 
-If you would like to improve the pypy3.9 recipe or build a new
+If you would like to improve the pypy3.8 recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/pypy3.9-feedstock are
+Note that all branches in the conda-forge/pypy3.8-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.
@@ -246,7 +246,4 @@ Feedstock Maintainers
 * [@ocefpaf](https://github.com/ocefpaf/)
 * [@ohadravid](https://github.com/ohadravid/)
 * [@omerbenamram](https://github.com/omerbenamram/)
-
-
-<!-- dummy commit to enable rerendering -->
 

--- a/README.md
+++ b/README.md
@@ -247,3 +247,6 @@ Feedstock Maintainers
 * [@ohadravid](https://github.com/ohadravid/)
 * [@omerbenamram](https://github.com/omerbenamram/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -95,7 +95,10 @@ requirements:
     - python {{ name_suffix }}.* *_{{ "".join(version.split(".")[:2]) }}_pypy
 
 test:
+  requires:
+    - m2-bash  # [win]
   commands:
+    - bash -c "pypy3 --version"  # [win]
     - pypy3 --help
     - pypy3 -c "import platform; print(platform._sys_version())"
     - pypy3 -c "import tkinter; tkinter.Tk()"                                                    # [not unix]


### PR DESCRIPTION
We encountered DLL loading issues for PyPy if run via Bash from `m2-bash` under Windows.
The odd thing is, that this is happening for the same PyPy builds that worked previously.
Could be a change in the CI worker's base image or something of similar nature.

Hi! This is the friendly automated conda-forge-webservice.

I've rerendered the recipe as instructed in #96.


Here's a checklist to do before merging.
- [ ] Bump the build number if needed.

Fixes #96